### PR TITLE
OPS-3896 change attribute ses_smtp_password

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check the [examples](examples) directory.
 | Name | Description |
 |------|-------------|
 | this\_access\_key | IAM Access Key of the created user, used as the STMP user name |
-| this\_ses\_smtp\_password | The secret access key converted into an SES SMTP password |
+| this\_ses\_smtp\_password\_v4 | The secret access key converted into an SES SMTP password |
 | this\_user\_arn | ARN of the IAM user |
 | this\_user\_name | IAM user name |
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check the [examples](examples) directory.
 | Name | Description |
 |------|-------------|
 | this\_access\_key | IAM Access Key of the created user, used as the STMP user name |
-| this\_ses\_smtp\_password\_v4 | The secret access key converted into an SES SMTP password |
+| this\_ses\_smtp\_password | The secret access key converted into an SES SMTP password |
 | this\_user\_arn | ARN of the IAM user |
 | this\_user\_name | IAM user name |
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.49.0"
+  version = "~> 3.5.0"
   region  = "eu-central-1"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "this_access_key" {
 }
 
 output "this_ses_smtp_password" {
-  value       = element(concat(aws_iam_access_key.this.*.ses_smtp_password, [""]), 0)
+  value       = element(concat(aws_iam_access_key.this.*.ses_smtp_password_v4, [""]), 0)
   description = "The secret access key converted into an SES SMTP password"
   sensitive   = true
 }


### PR DESCRIPTION
This change its required for aws provider >= 3.0.0
- [This has been deprecated in favour of ses_smtp_password_v4 ](https://github.com/terraform-providers/terraform-provider-aws/pull/14299)